### PR TITLE
Change the content of MVars to be a JsValue to match the mandrill API

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,11 @@ name := "scamandrill"
 
 organization := "io.github.scamandrill"
 
-version := "2.0.1-MT-SNAPSHOT"
+bintrayOrganization := Some("scamandrill")
+
+bintrayRepository := "scamandrill"
+
+bintrayReleaseOnPublish in ThisBuild := false
 
 licenses += ("Apache-2.0", url("https://spdx.org/licenses/Apache-2.0"))
 
@@ -35,16 +39,6 @@ libraryDependencies ++= {
     "com.typesafe.akka" %% "akka-testkit"     % akkaV % "test"
   )
 }
-
-publishTo <<= version { (v: String) =>
-  val mtmaven = "https://maven.getmealticket.com/"
-  if (v.trim.endsWith("SNAPSHOT"))
-    Some("meal-ticket-snapshots" at mtmaven + "repository/snapshots")
-  else
-    Some("meal-ticket-releases"  at mtmaven + "repository/releases")
-}
-credentials += Credentials(Path.userHome / ".ivy2" / ".credentials-releases")
-credentials += Credentials(Path.userHome / ".ivy2" / ".credentials-snapshots")
 
 publishArtifact in Test := false
 

--- a/build.sbt
+++ b/build.sbt
@@ -2,11 +2,7 @@ name := "scamandrill"
 
 organization := "io.github.scamandrill"
 
-bintrayOrganization := Some("scamandrill")
-
-bintrayRepository := "scamandrill"
-
-bintrayReleaseOnPublish in ThisBuild := false
+version := "2.0.1-MT-SNAPSHOT"
 
 licenses += ("Apache-2.0", url("https://spdx.org/licenses/Apache-2.0"))
 
@@ -39,6 +35,16 @@ libraryDependencies ++= {
     "com.typesafe.akka" %% "akka-testkit"     % akkaV % "test"
   )
 }
+
+publishTo <<= version { (v: String) =>
+  val mtmaven = "https://maven.getmealticket.com/"
+  if (v.trim.endsWith("SNAPSHOT"))
+    Some("meal-ticket-snapshots" at mtmaven + "repository/snapshots")
+  else
+    Some("meal-ticket-releases"  at mtmaven + "repository/releases")
+}
+credentials += Credentials(Path.userHome / ".ivy2" / ".credentials-releases")
+credentials += Credentials(Path.userHome / ".ivy2" / ".credentials-snapshots")
 
 publishArtifact in Test := false
 

--- a/src/main/scala/io/github/scamandrill/models/MandrillMessagesRequests.scala
+++ b/src/main/scala/io/github/scamandrill/models/MandrillMessagesRequests.scala
@@ -254,7 +254,7 @@ case class MMergeVars(rcpt: String, vars: List[MVars])
 case class MVars(name: String, content: JsValue)
 case object MVars extends ((String,JsValue) => MVars) {
   @deprecated(
-    message = "MVars should be a String->JsValue. Replace content with 'new JsString(content)'",
+    message = "Should be MVars(name:String, content:JsValue). Replace content with 'new JsString(content)'",
     since = "2.0.1"
   )
   def apply(name: String, content: String):MVars = MVars(name, new JsString(content))

--- a/src/main/scala/io/github/scamandrill/models/MandrillMessagesRequests.scala
+++ b/src/main/scala/io/github/scamandrill/models/MandrillMessagesRequests.scala
@@ -1,5 +1,7 @@
 package io.github.scamandrill.models
 
+import spray.json.{JsString, JsValue}
+
 /**
   * A message to be sent
   *
@@ -249,7 +251,15 @@ case class MMergeVars(rcpt: String, vars: List[MVars])
   * @param name    - the merge variable's name. Merge variable names are case-insensitive and may not start with _
   * @param content - the merge variable's content
   */
-case class MVars(name: String, content: String)
+case class MVars(name: String, content: JsValue)
+case object MVars extends ((String,JsValue) => MVars) {
+  @deprecated(
+    message = "MVars should be a String->JsValue. Replace content with 'new JsString(content)'",
+    since = "2.0.1"
+  )
+  def apply(name: String, content: String):MVars = MVars(name, new JsString(content))
+}
+
 
 /**
   * A single recipient's information.


### PR DESCRIPTION
Sometimes we need to be able to pass an array or complex object as merge vars.
The mandrill API documentation states that `content` from the `merge_vars` is of type `mixed`. I believe that JsValue is a better representation of what the API actually allows.


I overloaded the apply method so that existing uses of the MVars will still work, but deprecated that signature. Do you think it needs to be deprecated?