### PR TITLE
Updated scamandrill to work with play 2.6

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,10 +12,9 @@ licenses += ("Apache-2.0", url("https://spdx.org/licenses/Apache-2.0"))
 
 description := "Scala client for Mandrill api"
 
-scalaVersion := "2.11.7"
-val playVersion = "2.5.6"
+scalaVersion := "2.11.11"
 
-crossScalaVersions := Seq("2.10.5", "2.11.7")
+crossScalaVersions := Seq("2.10.6", "2.11.11")
 
 scalacOptions := Seq(
   "-feature", "-unchecked", "-deprecation", "-encoding", "utf8"
@@ -25,13 +24,13 @@ parallelExecution in Test := true
 
 libraryDependencies ++= {
   Seq(
-    "com.typesafe.play" %% "play-ws"          % playVersion,
-    "org.slf4j"         % "slf4j-api"         % "1.7.21"
+    "com.typesafe.play" %% "play-ahc-ws-standalone"       % "1.0.1",
+    "com.typesafe.play" %% "play-ws-standalone-json"      % "1.0.1",
+    "org.slf4j"         % "slf4j-api"                     % "1.7.25"
   ) ++ Seq(
-    "org.scalatest"            %%  "scalatest"       % "2.2.6"     % "test",
-    "com.typesafe.play"        %%  "play-test"       % playVersion % "test",
-    "org.slf4j"                %   "slf4j-simple"    % "1.7.21"    % "test",
-    "de.leanovate.play-mockws" %%  "play-mockws"     % "2.5.0"     % "test"
+    "org.scalatest"            %%  "scalatest"       % "2.2.6"   % "test",
+    "com.typesafe.play"        %%  "play-test"       % "2.6.0"   % "test",
+    "org.slf4j"                %   "slf4j-simple"    % "1.7.21"  % "test"
   )
 }
 

--- a/build.sbt
+++ b/build.sbt
@@ -12,9 +12,9 @@ licenses += ("Apache-2.0", url("https://spdx.org/licenses/Apache-2.0"))
 
 description := "Scala client for Mandrill api"
 
-scalaVersion := "2.11.11"
+scalaVersion := "2.12.2"
 
-crossScalaVersions := Seq("2.10.6", "2.11.11")
+crossScalaVersions := Seq("2.10.6", "2.11.11", "2.12.2")
 
 scalacOptions := Seq(
   "-feature", "-unchecked", "-deprecation", "-encoding", "utf8"
@@ -28,8 +28,8 @@ libraryDependencies ++= {
     "com.typesafe.play" %% "play-ws-standalone-json"      % "1.0.1",
     "org.slf4j"         % "slf4j-api"                     % "1.7.25"
   ) ++ Seq(
-    "org.scalatest"            %%  "scalatest"       % "2.2.6"   % "test",
-    "com.typesafe.play"        %%  "play-test"       % "2.6.0"   % "test",
+    "org.scalatest"            %%  "scalatest"       % "3.0.1"   % "test",
+    "com.typesafe.play"        %%  "play-test"       % "2.6.1"   % "test",
     "org.slf4j"                %   "slf4j-simple"    % "1.7.21"  % "test"
   )
 }

--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ description := "Scala client for Mandrill api"
 
 scalaVersion := "2.12.2"
 
-crossScalaVersions := Seq("2.10.6", "2.11.11", "2.12.2")
+crossScalaVersions := Seq("2.11.11", "2.12.2")
 
 scalacOptions := Seq(
   "-feature", "-unchecked", "-deprecation", "-encoding", "utf8"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.11
+sbt.version=0.13.15

--- a/project/scoverage.sbt
+++ b/project/scoverage.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.3.5")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.0")

--- a/src/main/scala/io/github/scamandrill/client/MandrillClient.scala
+++ b/src/main/scala/io/github/scamandrill/client/MandrillClient.scala
@@ -1,17 +1,17 @@
 package io.github.scamandrill.client
 
 import io.github.scamandrill.models.JsScalar.{JsScalarBoolean, JsScalarNumber, JsScalarString}
-import play.api.libs.ws.WSClient
 import io.github.scamandrill.models._
 import org.joda.time.DateTime
+import play.api.libs.ws.StandaloneWSClient
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
 
 case class MandrillClient(
-  ws: WSClient,
-  key: APIKey = APIKey(),
-  onShutdown: () => Future[Unit] = () => Future.successful(())
+                           ws: StandaloneWSClient,
+                           key: APIKey = APIKey(),
+                           onShutdown: () => Future[Unit] = () => Future.successful(())
 )(implicit val ec: ExecutionContext) extends ScamandrillSendReceive with MandrillClientProvider {
   import MandrillClient.Endpoints._
 

--- a/src/main/scala/io/github/scamandrill/client/MandrillClientProvider.scala
+++ b/src/main/scala/io/github/scamandrill/client/MandrillClientProvider.scala
@@ -41,7 +41,9 @@ trait MandrillClientProvider extends SimpleLogger with Provider[MandrillClient] 
 
 case class APIKey(key: String = APIKey.defaultKey)
 case object APIKey extends SimpleLogger {
-  implicit val writes: Writes[APIKey] = (key: APIKey) => JsString(key.key)
+  implicit val writes: Writes[APIKey] = new Writes[APIKey] {
+    override def writes(o: APIKey): JsValue = JsString(o.key)
+  }
 
   def defaultKey: String = {
     Try {

--- a/src/main/scala/io/github/scamandrill/client/MandrillClientProvider.scala
+++ b/src/main/scala/io/github/scamandrill/client/MandrillClientProvider.scala
@@ -41,9 +41,7 @@ trait MandrillClientProvider extends SimpleLogger with Provider[MandrillClient] 
 
 case class APIKey(key: String = APIKey.defaultKey)
 case object APIKey extends SimpleLogger {
-  implicit val writes = new Writes[APIKey] {
-    override def writes(key: APIKey): JsValue = JsString(key.key)
-  }
+  implicit val writes: Writes[APIKey] = (key: APIKey) => JsString(key.key)
 
   def defaultKey: String = {
     Try {

--- a/src/main/scala/io/github/scamandrill/client/MandrillResponseException.scala
+++ b/src/main/scala/io/github/scamandrill/client/MandrillResponseException.scala
@@ -1,13 +1,13 @@
 package io.github.scamandrill.client
 
-import play.api.libs.json.{JsObject, Json}
-import play.api.libs.ws.WSResponse
+import play.api.libs.json.{JsObject, Json, Writes, Reads}
+import play.api.libs.ws.StandaloneWSResponse
 
 case class MandrillError(status: String, code: Int, name: String, message: String)
 case object MandrillError {
-  implicit val reads = Json.reads[MandrillError]
-  implicit val writes = Json.writes[MandrillError]
+  implicit val reads: Reads[MandrillError] = Json.reads[MandrillError]
+  implicit val writes: Writes[MandrillError] = Json.writes[MandrillError]
 }
 
-case class MandrillResponseException(override val response: WSResponse,
+case class MandrillResponseException(override val response: StandaloneWSResponse,
                                      mandrillError: MandrillError) extends UnsuccessfulResponseException(response) {}

--- a/src/main/scala/io/github/scamandrill/client/Scamandrill.scala
+++ b/src/main/scala/io/github/scamandrill/client/Scamandrill.scala
@@ -2,41 +2,34 @@ package io.github.scamandrill.client
 
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
-import com.typesafe.config.ConfigFactory
-import play.api.{Configuration, Environment, Mode}
-import play.api.libs.ws.{WSClient, WSConfigParser}
-import play.api.libs.ws.ahc.{AhcConfigBuilder, AhcWSClient, AhcWSClientConfigParser}
+import com.typesafe.config.{Config, ConfigFactory}
+import play.api.libs.ws.ahc.{AhcWSClientConfigFactory, StandaloneAhcWSClient}
+import play.api.libs.ws.StandaloneWSClient
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class Scamandrill(val ws: WSClient, val ec: ExecutionContext, val onShutdown: () => Future[Unit]) extends MandrillClientProvider {
+class Scamandrill(val ws: StandaloneWSClient, val ec: ExecutionContext, val onShutdown: () => Future[Unit]) extends MandrillClientProvider {
 }
 
-object Scamandrill extends ((WSClient, ExecutionContext, () => Future[Unit]) => Scamandrill) {
+object Scamandrill extends ((StandaloneWSClient, ExecutionContext, () => Future[Unit]) => Scamandrill) {
 
-  override def apply(ws: WSClient, ec: ExecutionContext, onShutdown: () => Future[Unit] = () => Future.successful(())): Scamandrill = new Scamandrill(ws, ec, onShutdown)
-  def apply(ws: WSClient): Scamandrill = apply(ws, scala.concurrent.ExecutionContext.global)
-  def apply(ws: WSClient)(implicit ec: ExecutionContext): Scamandrill = apply(ws, ec)
+  override def apply(ws: StandaloneWSClient, ec: ExecutionContext, onShutdown: () => Future[Unit] = () => Future.successful(())): Scamandrill = new Scamandrill(ws, ec, onShutdown)
+  def apply(ws: StandaloneWSClient): Scamandrill = apply(ws, scala.concurrent.ExecutionContext.global)
+  def apply(ws: StandaloneWSClient)(implicit ec: ExecutionContext): Scamandrill = apply(ws, ec)
 
   /**
     * If no WSClient is provided to Scamandrill, it is the user's responsibility to shutdown Scamandrill when finished.
     * @param configuration this configuration is used to override the default values for the WSClient that Scamandrill constructs
     * @return
     */
-  def apply(configuration: Configuration): Scamandrill = {
+  def apply(configuration: Config): Scamandrill = {
     implicit val system = ActorSystem("scamandrill")
     implicit val mat = ActorMaterializer()
-    val env: Environment = Environment.simple(mode = Mode.Prod)
-
-    val _configuration = Configuration.reference ++ configuration
-
-    val wsParser = new WSConfigParser(_configuration, env)
-    val ahcParse = new AhcWSClientConfigParser(wsParser.parse(), _configuration, env)
-    val builder = new AhcConfigBuilder(ahcParse.parse())
-
-    apply(new AhcWSClient(builder.configure().build()), scala.concurrent.ExecutionContext.global, () => {
+    val clientConfig = AhcWSClientConfigFactory.forConfig(configuration.withFallback(ConfigFactory.load()))
+    apply(StandaloneAhcWSClient(clientConfig), scala.concurrent.ExecutionContext.global, () => {
       system.terminate().map(_ => ())(scala.concurrent.ExecutionContext.global)
     })
   }
-  def apply():Scamandrill = apply(Configuration.empty)
+
+  def apply(): Scamandrill = apply(ConfigFactory.load())
 }

--- a/src/main/scala/io/github/scamandrill/client/ScamandrillSendReceive.scala
+++ b/src/main/scala/io/github/scamandrill/client/ScamandrillSendReceive.scala
@@ -23,9 +23,11 @@ trait ScamandrillSendReceive extends SimpleLogger {
   val key: APIKey
   implicit val ec: ExecutionContext
 
-  private def authenticatedWriter[T](ow: Writes[T]): Writes[T] = (o: T) => ow.writes(o) match {
-    case js: JsObject => js + ("key" -> Json.toJson(key))
-    case value => value
+  private def authenticatedWriter[T](ow: Writes[T]): Writes[T] = new Writes[T] {
+    override def writes(o: T): JsValue = ow.writes(o) match {
+      case js: JsObject => js + ("key" -> Json.toJson(key))
+      case value => value
+    }
   }
 
   /**

--- a/src/main/scala/io/github/scamandrill/client/ScamandrillSendReceive.scala
+++ b/src/main/scala/io/github/scamandrill/client/ScamandrillSendReceive.scala
@@ -1,9 +1,11 @@
 package io.github.scamandrill.client
 
-import play.api.libs.ws.{WSClient, WSResponse}
+import play.api.libs.ws.{StandaloneWSClient, StandaloneWSResponse}
 import io.github.scamandrill.client.MandrillClient.Endpoints.Endpoint
 import io.github.scamandrill.utils.SimpleLogger
 import play.api.libs.json._
+import play.api.libs.ws.JsonBodyReadables._
+import play.api.libs.ws.JsonBodyWritables._
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.language.postfixOps
@@ -17,7 +19,7 @@ trait ScamandrillSendReceive extends SimpleLogger {
 
   private val serviceRoot: String = "https://mandrillapp.com/api/1.0"
 
-  val ws: WSClient
+  val ws: StandaloneWSClient
   val key: APIKey
   implicit val ec: ExecutionContext
 
@@ -39,15 +41,15 @@ trait ScamandrillSendReceive extends SimpleLogger {
     *       response code an error - the returned data will contain more detailed information
     */
   def executeQuery[Req, Res](endpoint: Endpoint, model: Req)(implicit writes: Writes[Req], reads: Reads[Res]): Future[Try[Res]] = {
-    def handleError(res: WSResponse, error: Option[JsValue]): Try[Res] = {
-      res.json.validate[MandrillError].fold(
+    def handleError(res: StandaloneWSResponse, error: Option[JsValue]): Try[Res] = {
+      res.body[JsValue].validate[MandrillError].fold(
         invalid = _ => Failure(new UnsuccessfulResponseException(res, error)),
         valid = me => Failure(new MandrillResponseException(res, me))
       )
     }
     ws.url(s"$serviceRoot$endpoint").withFollowRedirects(true).post(Json.toJson(model)(authenticatedWriter(writes))) map {
       case res if res.status == 200 =>
-        res.json.validate[Res](reads).fold(
+        res.body[JsValue].validate[Res](reads).fold(
           invalid = jsError => {
             logger.debug("Error parsing json from mandrill: " + Json.stringify(JsError.toJson(jsError)))
             handleError(res, Some(JsError.toJson(jsError)))

--- a/src/main/scala/io/github/scamandrill/client/UnsuccessfulResponseException.scala
+++ b/src/main/scala/io/github/scamandrill/client/UnsuccessfulResponseException.scala
@@ -1,6 +1,8 @@
 package io.github.scamandrill.client
 
 import play.api.libs.json.JsValue
-import play.api.libs.ws.WSResponse
+import play.api.libs.ws.StandaloneWSResponse
 
-class UnsuccessfulResponseException(val response: WSResponse, val error: Option[JsValue] = None) extends RuntimeException {}
+class UnsuccessfulResponseException(
+                                     val response: StandaloneWSResponse,
+                                     val error: Option[JsValue] = None) extends RuntimeException {}

--- a/src/main/scala/io/github/scamandrill/models/JsScalar.scala
+++ b/src/main/scala/io/github/scamandrill/models/JsScalar.scala
@@ -11,12 +11,16 @@ object JsScalar {
   case class JsScalarNumber(n: BigDecimal) extends JsScalar { override def underlying = JsNumber(n) }
   case class JsScalarBoolean(b: Boolean) extends JsScalar { override def underlying = JsBoolean(b) }
 
-  implicit val writes: Writes[JsScalar] = (o: JsScalar) => o.underlying
+  implicit val writes: Writes[JsScalar] = new Writes[JsScalar] {
+    override def writes(o: JsScalar): JsValue = o.underlying
+  }
 
-  implicit val reads: Reads[JsScalar] = {
-    case s: JsString => JsSuccess(JsScalarString(s.value))
-    case b: JsBoolean => JsSuccess(JsScalarBoolean(b.value))
-    case n: JsNumber => JsSuccess(JsScalarNumber(n.value))
-    case _ => JsError("JsScalar must be a String, Boolean or Number")
+  implicit val reads: Reads[JsScalar] = new Reads[JsScalar] {
+    override def reads(json: JsValue): JsResult[JsScalar] = json match {
+      case s: JsString => JsSuccess(JsScalarString(s.value))
+      case b: JsBoolean => JsSuccess(JsScalarBoolean(b.value))
+      case n: JsNumber => JsSuccess(JsScalarNumber(n.value))
+      case _ => JsError("JsScalar must be a String, Boolean or Number")
+    }
   }
 }

--- a/src/main/scala/io/github/scamandrill/models/JsScalar.scala
+++ b/src/main/scala/io/github/scamandrill/models/JsScalar.scala
@@ -1,6 +1,6 @@
 package io.github.scamandrill.models
 
-import play.api.libs.json.{JsResult, JsSuccess, Reads, _}
+import play.api.libs.json.{JsSuccess, Reads, _}
 
 sealed trait JsScalar {
   def underlying: JsValue
@@ -11,16 +11,12 @@ object JsScalar {
   case class JsScalarNumber(n: BigDecimal) extends JsScalar { override def underlying = JsNumber(n) }
   case class JsScalarBoolean(b: Boolean) extends JsScalar { override def underlying = JsBoolean(b) }
 
-  implicit val writes = new Writes[JsScalar] {
-    override def writes(o: JsScalar): JsValue = o.underlying
-  }
+  implicit val writes: Writes[JsScalar] = (o: JsScalar) => o.underlying
 
-  implicit val reads = new Reads[JsScalar] {
-    override def reads(json: JsValue): JsResult[JsScalar] = json match {
-      case s: JsString => JsSuccess(JsScalarString(s.value))
-      case b: JsBoolean => JsSuccess(JsScalarBoolean(b.value))
-      case n: JsNumber => JsSuccess(JsScalarNumber(n.value))
-      case x => JsError("JsScalar must be a String, Boolean or Number")
-    }
+  implicit val reads: Reads[JsScalar] = {
+    case s: JsString => JsSuccess(JsScalarString(s.value))
+    case b: JsBoolean => JsSuccess(JsScalarBoolean(b.value))
+    case n: JsNumber => JsSuccess(JsScalarNumber(n.value))
+    case _ => JsError("JsScalar must be a String, Boolean or Number")
   }
 }

--- a/src/main/scala/io/github/scamandrill/models/MandrillInboundResponses.scala
+++ b/src/main/scala/io/github/scamandrill/models/MandrillInboundResponses.scala
@@ -1,7 +1,7 @@
 package io.github.scamandrill.models
 
 import org.joda.time.DateTime
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, Reads}
 
 /**
   * Information about the inbound domain
@@ -15,7 +15,7 @@ case class MInboundDomainResponse(domain: String,
                                   valid_mx: Boolean)
 case object MInboundDomainResponse {
   implicit val dt = MandrillDateFormats.DATETIME_FORMAT
-  implicit val reads = Json.reads[MInboundDomainResponse]
+  implicit val reads: Reads[MInboundDomainResponse] = Json.reads[MInboundDomainResponse]
 }
 
 /**
@@ -29,7 +29,7 @@ case class MInboundRouteResponse(id: String,
                                  pattern: String,
                                  url: String)
 case object MInboundRouteResponse {
-  implicit val reads = Json.reads[MInboundRouteResponse]
+  implicit val reads: Reads[MInboundRouteResponse] = Json.reads[MInboundRouteResponse]
 }
 
 /**
@@ -41,7 +41,7 @@ case object MInboundRouteResponse {
   */
 case class MInboundRawResponse(email: String,
                                pattern: String,
-                               url: Boolean)
+                               url: String)
 case object MInboundRawResponse {
-  implicit val reads = Json.reads[MInboundRawResponse]
+  implicit val reads: Reads[MInboundRawResponse] = Json.reads[MInboundRawResponse]
 }

--- a/src/main/scala/io/github/scamandrill/models/MandrillMessagesRequests.scala
+++ b/src/main/scala/io/github/scamandrill/models/MandrillMessagesRequests.scala
@@ -25,7 +25,12 @@ case object MAttachmetOrImage {
   */
 case class MVars(name: String, content: JsValue)
 case object MVars extends ((String, JsValue) => MVars) {
-  implicit val writes: Writes[MVars] = Json.writes[MVars]
+  implicit val writes: Writes[MVars] = (o: MVars) => {
+    Json.obj(
+      "name" -> o.name,
+      "content" -> o.content
+    )
+  }
 
   def apply[T](name: String, content: T)(implicit cw: Writes[T]): MVars = new MVars(name, Json.toJson(content))
 }
@@ -55,8 +60,8 @@ case object MTo {
 
 case class MHeaders(underlying: Map[String, String]) extends Optional[MHeaders]
 case object MHeaders extends (Map[String,String] => MHeaders) {
-  implicit val writes: Writes[MHeaders] = new Writes[MHeaders] {
-    override def writes(o: MHeaders): JsValue = Json.toJson(o.underlying)
+  implicit val writes: Writes[MHeaders] = (o: MHeaders) => {
+    Json.toJson(o.underlying)
   }
   def apply(entries: (String, String)*): MHeaders = MHeaders(Map(entries:_*))
   def apply(entries: TraversableOnce[MHeader]): MHeaders = MHeaders(entries.map(e => (e.name, e.value)).toSeq:_*)
@@ -81,8 +86,8 @@ case class MMetadataEntry(key: String, value: JsScalar)
   */
 case class MMetadata(entries: MMetadataEntry*) extends Optional[MMetadata] {}
 case object MMetadata {
-  implicit val writes: Writes[MMetadata] = new Writes[MMetadata] {
-    override def writes(o: MMetadata): JsValue = Json.toJson(Map(o.entries.map(e => (e.key, e.value)):_*))
+  implicit val writes: Writes[MMetadata] = (o: MMetadata) => {
+    Json.toJson(Map(o.entries.map(e => (e.key, e.value)):_*))
   }
 }
 
@@ -230,7 +235,7 @@ class MSendMsg(val html: String,
       images)
   }
 
-  override def equals(other: Any) = other match {
+  override def equals(other: Any): Boolean = other match {
     case o: MSendMsg =>
       o.html == this.html &&
         o.html == this.html &&
@@ -268,42 +273,40 @@ class MSendMsg(val html: String,
   }
 }
 object MSendMsg {
-  implicit val writes = new Writes[MSendMsg] {
-    override def writes(msg: MSendMsg): JsValue = Json.obj(
-      "html" -> msg.html,
-      "text" -> msg.text,
-      "subject" -> msg.subject,
-      "from_email" -> msg.from_email,
-      "from_name" -> msg.from_name,
-      "to" -> msg.to,
-      "headers" -> msg.headers,
-      "important" -> msg.important,
-      "track_opens" -> msg.track_opens,
-      "track_clicks" -> msg.track_clicks,
-      "auto_text" -> msg.auto_text,
-      "auto_html" -> msg.auto_html,
-      "inline_css" -> msg.inline_css,
-      "url_strip_qs" -> msg.url_strip_qs,
-      "preserve_recipients" -> msg.preserve_recipients,
-      "view_content_link" -> msg.view_content_link,
-      "bcc_address" -> msg.bcc_address,
-      "tracking_domain" -> msg.tracking_domain,
-      "signing_domain" -> msg.signing_domain,
-      "return_path_domain" -> msg.return_path_domain,
-      "merge" -> msg.merge,
-      "global_merge_vars" -> msg.global_merge_vars,
-      "merge_vars" -> msg.merge_vars,
-      "tags" -> msg.tags,
-      "subaccount" -> msg.subaccount,
-      "google_analytics_domains" -> msg.google_analytics_domains,
-      "google_analytics_campaign" -> msg.google_analytics_campaign,
-      "metadata" -> msg.metadata,
-      "recipient_metadata" -> msg.recipient_metadata,
-      "attachments" -> msg.attachments,
-      "images" -> msg.images,
-      "merge_language" -> msg.merge_language
-    )
-  }
+  implicit val writes: Writes[MSendMsg] = (msg: MSendMsg) => Json.obj(
+    "html" -> msg.html,
+    "text" -> msg.text,
+    "subject" -> msg.subject,
+    "from_email" -> msg.from_email,
+    "from_name" -> msg.from_name,
+    "to" -> msg.to,
+    "headers" -> msg.headers,
+    "important" -> msg.important,
+    "track_opens" -> msg.track_opens,
+    "track_clicks" -> msg.track_clicks,
+    "auto_text" -> msg.auto_text,
+    "auto_html" -> msg.auto_html,
+    "inline_css" -> msg.inline_css,
+    "url_strip_qs" -> msg.url_strip_qs,
+    "preserve_recipients" -> msg.preserve_recipients,
+    "view_content_link" -> msg.view_content_link,
+    "bcc_address" -> msg.bcc_address,
+    "tracking_domain" -> msg.tracking_domain,
+    "signing_domain" -> msg.signing_domain,
+    "return_path_domain" -> msg.return_path_domain,
+    "merge" -> msg.merge,
+    "global_merge_vars" -> msg.global_merge_vars,
+    "merge_vars" -> msg.merge_vars,
+    "tags" -> msg.tags,
+    "subaccount" -> msg.subaccount,
+    "google_analytics_domains" -> msg.google_analytics_domains,
+    "google_analytics_campaign" -> msg.google_analytics_campaign,
+    "metadata" -> msg.metadata,
+    "recipient_metadata" -> msg.recipient_metadata,
+    "attachments" -> msg.attachments,
+    "images" -> msg.images,
+    "merge_language" -> msg.merge_language
+  )
 }
 
 

--- a/src/main/scala/io/github/scamandrill/models/MandrillMessagesRequests.scala
+++ b/src/main/scala/io/github/scamandrill/models/MandrillMessagesRequests.scala
@@ -25,11 +25,13 @@ case object MAttachmetOrImage {
   */
 case class MVars(name: String, content: JsValue)
 case object MVars extends ((String, JsValue) => MVars) {
-  implicit val writes: Writes[MVars] = (o: MVars) => {
-    Json.obj(
-      "name" -> o.name,
-      "content" -> o.content
-    )
+  implicit val writes: Writes[MVars] = new Writes[MVars]() {
+    override def writes(o: MVars): JsValue = {
+      Json.obj(
+        "name" -> o.name,
+        "content" -> o.content
+      )
+    }
   }
 
   def apply[T](name: String, content: T)(implicit cw: Writes[T]): MVars = new MVars(name, Json.toJson(content))
@@ -60,8 +62,8 @@ case object MTo {
 
 case class MHeaders(underlying: Map[String, String]) extends Optional[MHeaders]
 case object MHeaders extends (Map[String,String] => MHeaders) {
-  implicit val writes: Writes[MHeaders] = (o: MHeaders) => {
-    Json.toJson(o.underlying)
+  implicit val writes: Writes[MHeaders] = new Writes[MHeaders] {
+    override def writes(o: MHeaders): JsValue = Json.toJson(o.underlying)
   }
   def apply(entries: (String, String)*): MHeaders = MHeaders(Map(entries:_*))
   def apply(entries: TraversableOnce[MHeader]): MHeaders = MHeaders(entries.map(e => (e.name, e.value)).toSeq:_*)
@@ -86,8 +88,8 @@ case class MMetadataEntry(key: String, value: JsScalar)
   */
 case class MMetadata(entries: MMetadataEntry*) extends Optional[MMetadata] {}
 case object MMetadata {
-  implicit val writes: Writes[MMetadata] = (o: MMetadata) => {
-    Json.toJson(Map(o.entries.map(e => (e.key, e.value)):_*))
+  implicit val writes: Writes[MMetadata] = new Writes[MMetadata] {
+    override def writes(o: MMetadata): JsValue = Json.toJson(Map(o.entries.map(e => (e.key, e.value)):_*))
   }
 }
 
@@ -273,40 +275,42 @@ class MSendMsg(val html: String,
   }
 }
 object MSendMsg {
-  implicit val writes: Writes[MSendMsg] = (msg: MSendMsg) => Json.obj(
-    "html" -> msg.html,
-    "text" -> msg.text,
-    "subject" -> msg.subject,
-    "from_email" -> msg.from_email,
-    "from_name" -> msg.from_name,
-    "to" -> msg.to,
-    "headers" -> msg.headers,
-    "important" -> msg.important,
-    "track_opens" -> msg.track_opens,
-    "track_clicks" -> msg.track_clicks,
-    "auto_text" -> msg.auto_text,
-    "auto_html" -> msg.auto_html,
-    "inline_css" -> msg.inline_css,
-    "url_strip_qs" -> msg.url_strip_qs,
-    "preserve_recipients" -> msg.preserve_recipients,
-    "view_content_link" -> msg.view_content_link,
-    "bcc_address" -> msg.bcc_address,
-    "tracking_domain" -> msg.tracking_domain,
-    "signing_domain" -> msg.signing_domain,
-    "return_path_domain" -> msg.return_path_domain,
-    "merge" -> msg.merge,
-    "global_merge_vars" -> msg.global_merge_vars,
-    "merge_vars" -> msg.merge_vars,
-    "tags" -> msg.tags,
-    "subaccount" -> msg.subaccount,
-    "google_analytics_domains" -> msg.google_analytics_domains,
-    "google_analytics_campaign" -> msg.google_analytics_campaign,
-    "metadata" -> msg.metadata,
-    "recipient_metadata" -> msg.recipient_metadata,
-    "attachments" -> msg.attachments,
-    "images" -> msg.images,
-    "merge_language" -> msg.merge_language
-  )
+  implicit val writes: Writes[MSendMsg] = new Writes[MSendMsg] {
+    override def writes(msg: MSendMsg): JsValue = Json.obj(
+      "html" -> msg.html,
+      "text" -> msg.text,
+      "subject" -> msg.subject,
+      "from_email" -> msg.from_email,
+      "from_name" -> msg.from_name,
+      "to" -> msg.to,
+      "headers" -> msg.headers,
+      "important" -> msg.important,
+      "track_opens" -> msg.track_opens,
+      "track_clicks" -> msg.track_clicks,
+      "auto_text" -> msg.auto_text,
+      "auto_html" -> msg.auto_html,
+      "inline_css" -> msg.inline_css,
+      "url_strip_qs" -> msg.url_strip_qs,
+      "preserve_recipients" -> msg.preserve_recipients,
+      "view_content_link" -> msg.view_content_link,
+      "bcc_address" -> msg.bcc_address,
+      "tracking_domain" -> msg.tracking_domain,
+      "signing_domain" -> msg.signing_domain,
+      "return_path_domain" -> msg.return_path_domain,
+      "merge" -> msg.merge,
+      "global_merge_vars" -> msg.global_merge_vars,
+      "merge_vars" -> msg.merge_vars,
+      "tags" -> msg.tags,
+      "subaccount" -> msg.subaccount,
+      "google_analytics_domains" -> msg.google_analytics_domains,
+      "google_analytics_campaign" -> msg.google_analytics_campaign,
+      "metadata" -> msg.metadata,
+      "recipient_metadata" -> msg.recipient_metadata,
+      "attachments" -> msg.attachments,
+      "images" -> msg.images,
+      "merge_language" -> msg.merge_language
+    )
+  }
 }
 
 

--- a/src/main/scala/io/github/scamandrill/models/MandrillMessagesRequests.scala
+++ b/src/main/scala/io/github/scamandrill/models/MandrillMessagesRequests.scala
@@ -13,8 +13,8 @@ import play.api.libs.json._
   */
 case class MAttachmetOrImage(`type`: String, name: String, content: String)
 case object MAttachmetOrImage {
-  implicit val writes = Json.writes[MAttachmetOrImage]
-  implicit val reads = Json.reads[MAttachmetOrImage]
+  implicit val writes: Writes[MAttachmetOrImage] = Json.writes[MAttachmetOrImage]
+  implicit val reads: Reads[MAttachmetOrImage] = Json.reads[MAttachmetOrImage]
 }
 
 /**
@@ -25,7 +25,7 @@ case object MAttachmetOrImage {
   */
 case class MVars(name: String, content: JsValue)
 case object MVars extends ((String, JsValue) => MVars) {
-  implicit val writes = Json.writes[MVars]
+  implicit val writes: Writes[MVars] = Json.writes[MVars]
 
   def apply[T](name: String, content: T)(implicit cw: Writes[T]): MVars = new MVars(name, Json.toJson(content))
 }
@@ -38,7 +38,7 @@ case object MVars extends ((String, JsValue) => MVars) {
   */
 case class MMergeVars(rcpt: String, vars: List[MVars])
 case object MMergeVars {
-  implicit val writes = Json.writes[MMergeVars]
+  implicit val writes: Writes[MMergeVars] = Json.writes[MMergeVars]
 }
 
 /**
@@ -50,12 +50,12 @@ case object MMergeVars {
   */
 case class MTo(email: String, name: Option[String] = None, `type`: String = "to")
 case object MTo {
-  implicit val writes = Json.writes[MTo]
+  implicit val writes: Writes[MTo] = Json.writes[MTo]
 }
 
 case class MHeaders(underlying: Map[String, String]) extends Optional[MHeaders]
 case object MHeaders extends (Map[String,String] => MHeaders) {
-  implicit val writes = new Writes[MHeaders] {
+  implicit val writes: Writes[MHeaders] = new Writes[MHeaders] {
     override def writes(o: MHeaders): JsValue = Json.toJson(o.underlying)
   }
   def apply(entries: (String, String)*): MHeaders = MHeaders(Map(entries:_*))
@@ -69,7 +69,7 @@ case object MHeaders extends (Map[String,String] => MHeaders) {
   */
 case class MHeader(name: String, value: String)
 case object MHeader {
-  implicit val writes = Json.writes[MHeader]
+  implicit val writes: Writes[MHeader] = Json.writes[MHeader]
 }
 
 case class MMetadataEntry(key: String, value: JsScalar)
@@ -81,7 +81,7 @@ case class MMetadataEntry(key: String, value: JsScalar)
   */
 case class MMetadata(entries: MMetadataEntry*) extends Optional[MMetadata] {}
 case object MMetadata {
-  implicit val writes = new Writes[MMetadata] {
+  implicit val writes: Writes[MMetadata] = new Writes[MMetadata] {
     override def writes(o: MMetadata): JsValue = Json.toJson(Map(o.entries.map(e => (e.key, e.value)):_*))
   }
 }
@@ -94,7 +94,7 @@ case object MMetadata {
   */
 case class MRecipientMetadata(rcpt: String, values: MMetadata)
 case object MRecipientMetadata {
-  implicit val writes = Json.writes[MRecipientMetadata]
+  implicit val writes: Writes[MRecipientMetadata] = Json.writes[MRecipientMetadata]
 }
 
 /**
@@ -322,7 +322,7 @@ case class MSendMessage(message: MSendMsg,
 
 case object MSendMessage {
   implicit val dt = MandrillDateFormats.DATETIME_FORMAT
-  implicit val writes = Json.writes[MSendMessage]
+  implicit val writes: Writes[MSendMessage] = Json.writes[MSendMessage]
 }
 
 /**
@@ -343,7 +343,7 @@ case class MSendTemplateMessage(template_name: String,
                                 send_at: Option[DateTime] = None)
 case object MSendTemplateMessage {
   implicit val dt = MandrillDateFormats.DATETIME_FORMAT
-  implicit val writes = Json.writes[MSendTemplateMessage]
+  implicit val writes: Writes[MSendTemplateMessage] = Json.writes[MSendTemplateMessage]
 }
 
 /**
@@ -366,7 +366,7 @@ case class MSearch(query: Option[String] = None,
                    limit: Int = 100)
 case object MSearch {
   implicit val d = MandrillDateFormats.DATE_FORMAT
-  implicit val writes = Json.writes[MSearch]
+  implicit val writes: Writes[MSearch] = Json.writes[MSearch]
 }
 
 /**
@@ -385,7 +385,7 @@ case class MSearchTimeSeries(query: String,
                              senders: List[String] = List.empty)
 case object MSearchTimeSeries {
   implicit val d = MandrillDateFormats.DATE_FORMAT
-  implicit val writes = Json.writes[MSearchTimeSeries]
+  implicit val writes: Writes[MSearchTimeSeries] = Json.writes[MSearchTimeSeries]
 }
 
 /**
@@ -395,7 +395,7 @@ case object MSearchTimeSeries {
   */
 case class MMessageInfo(id: String)
 case object MMessageInfo {
-  implicit val writes = Json.writes[MMessageInfo]
+  implicit val writes: Writes[MMessageInfo] = Json.writes[MMessageInfo]
 }
 
 /**
@@ -405,7 +405,7 @@ case object MMessageInfo {
   */
 case class MParse(raw_message: String)
 case object MParse {
-  implicit val writes = Json.writes[MParse]
+  implicit val writes: Writes[MParse] = Json.writes[MParse]
 }
 
 /**
@@ -430,7 +430,7 @@ case class MSendRaw(raw_message: String,
                     return_path_domain: Option[String] = None)
 case object MSendRaw {
   implicit val dt = MandrillDateFormats.DATETIME_FORMAT
-  implicit val writes = Json.writes[MSendRaw]
+  implicit val writes: Writes[MSendRaw] = Json.writes[MSendRaw]
 }
 
 /**
@@ -440,7 +440,7 @@ case object MSendRaw {
   */
 case class MListSchedule(to: String)
 case object MListSchedule {
-  implicit val writes = Json.writes[MListSchedule]
+  implicit val writes: Writes[MListSchedule] = Json.writes[MListSchedule]
 }
 
 /**
@@ -450,7 +450,7 @@ case object MListSchedule {
   */
 case class MCancelSchedule(id: String)
 case object MCancelSchedule {
-  implicit val writes = Json.writes[MCancelSchedule]
+  implicit val writes: Writes[MCancelSchedule] = Json.writes[MCancelSchedule]
 }
 
 /**
@@ -462,5 +462,5 @@ case object MCancelSchedule {
 case class MReSchedule(id: String, send_at: DateTime)
 case object MReSchedule {
   implicit val d = MandrillDateFormats.DATETIME_FORMAT
-  implicit val writes = Json.writes[MReSchedule]
+  implicit val writes: Writes[MReSchedule] = Json.writes[MReSchedule]
 }

--- a/src/main/scala/io/github/scamandrill/models/MandrillMessagesResponses.scala
+++ b/src/main/scala/io/github/scamandrill/models/MandrillMessagesResponses.scala
@@ -174,16 +174,16 @@ case object MToResponse {
 /**
   * The content of the message
   *
-  * @param ts         - the Unix timestamp from when this message was sent
-  * @param _id        - the message's unique id
-  * @param from_email - the email address of the sender
-  * @param from_name  - the alias of the sender (if any)
-  * @param subject    - the message's subject line
-  * @param to         - the message recipient's information
-  * @param tags       - list of tags on this message
-  * @param text       - the text part of the message, if any
-  * @param html       - the HTML part of the message, if any
-  * @param attachemnt - an array of any attachments that can be found in the message
+  * @param ts          - the Unix timestamp from when this message was sent
+  * @param _id         - the message's unique id
+  * @param from_email  - the email address of the sender
+  * @param from_name   - the alias of the sender (if any)
+  * @param subject     - the message's subject line
+  * @param to          - the message recipient's information
+  * @param tags        - list of tags on this message
+  * @param text        - the text part of the message, if any
+  * @param html        - the HTML part of the message, if any
+  * @param attachments - an array of any attachments that can be found in the message
   */
 case class MContentResponse(ts: Int,
                             _id: String,

--- a/src/main/scala/io/github/scamandrill/models/MandrillUserRequests.scala
+++ b/src/main/scala/io/github/scamandrill/models/MandrillUserRequests.scala
@@ -8,5 +8,7 @@ import play.api.libs.json.{JsObject, JsValue, Writes}
   */
 case class MVoid()
 case object MVoid {
-  implicit val writes: Writes[MVoid] = (_: MVoid) => JsObject(Map[String, JsValue]())
+  implicit val writes: Writes[MVoid] = new Writes[MVoid] {
+    override def writes(o: MVoid): JsValue = JsObject(Map[String, JsValue]())
+  }
 }

--- a/src/main/scala/io/github/scamandrill/models/MandrillUserRequests.scala
+++ b/src/main/scala/io/github/scamandrill/models/MandrillUserRequests.scala
@@ -8,7 +8,5 @@ import play.api.libs.json.{JsObject, JsValue, Writes}
   */
 case class MVoid()
 case object MVoid {
-  implicit val writes = new Writes[MVoid] {
-    override def writes(o: MVoid): JsValue = JsObject(Map[String, JsValue]())
-  }
+  implicit val writes: Writes[MVoid] = (_: MVoid) => JsObject(Map[String, JsValue]())
 }

--- a/src/test/scala/io/github/scamandrill/MandrillSpec.scala
+++ b/src/test/scala/io/github/scamandrill/MandrillSpec.scala
@@ -1,56 +1,95 @@
 package io.github.scamandrill
 
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import akka.stream.scaladsl.StreamConverters
+import akka.util.ByteString
 import com.typesafe.config.ConfigFactory
 import io.github.scamandrill.client.{MandrillClient, Scamandrill}
 import io.github.scamandrill.utils.SimpleLogger
-import mockws.MockWS
 import org.scalatest._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.{Seconds, Span}
 import play.api.Configuration
-import play.api.libs.ws.WSClient
-import play.api.mvc.{Action, Results}
-import play.api.test.Helpers._
 import play.api.libs.json.Json
+import play.api.libs.ws.{InMemoryBody, StandaloneWSClient, StandaloneWSRequest, StandaloneWSResponse}
 
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ExecutionContext, Future}
 
 trait MandrillSpec extends FlatSpec with Matchers with SimpleLogger with ScalaFutures with BeforeAndAfterAll {
   this: Suite =>
   val scamandrill = Scamandrill()
+  implicit val system = ActorSystem("scamandrill-test")
+  implicit val mat = ActorMaterializer()
 
   val utcDateTimeParser = MandrillTestUtils.utcDateTimeParser
   val dateParser = MandrillTestUtils.dateParser
 
-  def defaultTimeout = {
-    Configuration(ConfigFactory.load("application.conf")).getInt("mandrill.timoutInSeconds") match {
-      case Some(t) => timeout(Span(t, Seconds))
-      case None =>
-        fail("Unable to load mandrill.timeoutInSeconds from application.conf")
-    }
-  }
+  def defaultTimeout =
+    timeout(Span(Configuration(ConfigFactory.load("application.conf")).get[Int]("mandrill.timoutInSeconds"), Seconds))
 
   def SCAMANDRILL_API_KEY = sys.env.get("SCAMANDRILL_API_KEY")
   val actualClient: Option[MandrillClient] = SCAMANDRILL_API_KEY.map(scamandrill.getClient)
 
-  def withMockClient(path: String, returnError: Boolean = false, raiseException: Boolean = false)(f: (WSClient) => Unit) = {
-    f(MockWS {
-      case (POST, p) if p == s"https://mandrillapp.com/api/1.0$path" => Action(request => {
-        (request.body.asJson, Option(this.getClass.getClassLoader.getResourceAsStream(s"requests$path")).map(Json.parse)) match {
-          case (Some(actual), Some(expected)) =>
-            actual shouldBe expected
-          case _ => fail(s"Unable to get actual and expected requests for $path")
-        }
-        if(returnError) {
-          Results.InternalServerError.sendResource(s"errors$path")
-        } else if(raiseException) {
-          throw new RuntimeException("This is a simulated unhandled exception")
+  def withMockClient(path: String, returnError: Boolean = false, raiseException: Boolean = false)(f: (StandaloneWSClient) => Unit) = {
+    def loadFile(prefix: String): Future[ByteString] = {
+      StreamConverters
+        .fromInputStream(in = () => this.getClass.getClassLoader.getResourceAsStream(s"$prefix$path"))
+        .runFold(ByteString())(_ ++ _)
+    }
+
+    val test = (request: StandaloneWSRequest) => {
+      if (request.url === s"https://mandrillapp.com/api/1.0$path") {
+        if (returnError) {
+          loadFile("errors").map { result =>
+              MockWSResponse(
+                bytes = Some(result),
+                status = 500,
+                headers = Map(),
+                statusText = "INTERNAL_SERVER_ERROR",
+                cookies = Seq()
+              ).asInstanceOf[StandaloneWSResponse]
+            }
+        } else if (raiseException) {
+          Future.failed(new RuntimeException("This is a simulated unhandled exception"))
+        } else if (request.method == "POST") {
+          loadFile("requests").flatMap { expectedContent =>
+            request.body match {
+              case InMemoryBody(actualContent) =>
+                val actualJson = Json.parse(actualContent.utf8String)
+                val expectedJson = Json.parse(expectedContent.utf8String)
+                actualJson shouldBe expectedJson
+
+                loadFile("responses").map { result =>
+                  MockWSResponse(
+                    bytes = Some(result),
+                    status = 200,
+                    headers = Map(),
+                    statusText = "OK",
+                    cookies = Seq()
+                  ).asInstanceOf[StandaloneWSResponse]
+                }
+              case _ => fail("Unable to verify the request content")
+            }
+
+          }
         } else {
-          Results.Ok.sendResource(s"responses$path")
+          loadFile("responses").map { result =>
+            MockWSResponse(
+              bytes = Some(result),
+              status = 200,
+              headers = Map(),
+              statusText = "OK",
+              cookies = Seq()
+            ).asInstanceOf[StandaloneWSResponse]
+          }
         }
-      })
-      case _ => Action(request => fail(s"expected: https://mandrillapp.com/api/1.0$path, actual: ${request.uri}"))
-    })
+      } else {
+        fail(s"expected: https://mandrillapp.com/api/1.0$path, actual: ${request.uri}")
+      }
+    }
+
+    f(MockWSRequest.MockWS(test = test))
   }
 
   import scala.concurrent.ExecutionContext.global
@@ -58,6 +97,7 @@ trait MandrillSpec extends FlatSpec with Matchers with SimpleLogger with ScalaFu
 
   override def afterAll(): Unit = {
     scamandrill.shutdown()
+    system.terminate()
   }
 
 }

--- a/src/test/scala/io/github/scamandrill/MockWSRequest.scala
+++ b/src/test/scala/io/github/scamandrill/MockWSRequest.scala
@@ -1,0 +1,121 @@
+package io.github.scamandrill
+
+import java.net.URI
+
+import akka.stream.scaladsl.Source
+import akka.util.ByteString
+import play.api.libs.ws.{BodyWritable, EmptyBody, StandaloneWSClient, StandaloneWSRequest, StandaloneWSResponse, WSAuthScheme, WSBody, WSCookie, WSProxyServer, WSRequestFilter, WSSignatureCalculator}
+
+import scala.concurrent.Future
+import scala.concurrent.duration.Duration
+
+case class MockWSRequest(
+  test: (StandaloneWSRequest => Future[StandaloneWSResponse]),
+  body: WSBody,
+  auth: Option[(String, String, WSAuthScheme)],
+  followRedirects: Option[Boolean],
+  headers: Map[String, Seq[String]],
+  contentType: Option[String],
+  cookies: Seq[WSCookie],
+  virtualHost: Option[String],
+  method: String,
+  queryString: Map[String, Seq[String]],
+  proxyServer: Option[WSProxyServer],
+  calc: Option[WSSignatureCalculator],
+  url: String,
+  uri: URI,
+  requestTimeout: Option[Int]
+) extends StandaloneWSRequest {
+
+  override type Self = MockWSRequest
+
+  override def withFollowRedirects(follow: Boolean): Self = this.copy(followRedirects = Some(follow))
+
+  override def withHttpHeaders(headers: (String, String)*): Self = {
+    val additional: Iterable[(String, Seq[String])] = headers.groupBy(_._1).map {
+      case (key, group) => (key, group.map(_._2))
+    }
+
+    this.copy(headers = this.headers ++ additional)
+  }
+
+  override def sign(calc: WSSignatureCalculator): Self = this
+
+  override def withRequestFilter(filter: WSRequestFilter): Self = this
+
+  override def withCookies(cookies: WSCookie*): Self = this.copy(cookies = this.cookies ++ cookies.toSeq)
+
+  override def put[T](body: T)(implicit writable: BodyWritable[T]): Future[Response] =
+    this.withBody(body).execute("PUT")
+
+  override def patch[T](body: T)(implicit writable: BodyWritable[T]): Future[Response] =
+    this.withBody(body).execute("PATCH")
+
+  override def post[T](body: T)(implicit writable: BodyWritable[T]): Future[Response] =
+    this.withBody(body).execute("POST")
+
+  override def options(): Future[Response] = this.execute("OPTIONS")
+
+  override def execute(method: String): Future[Response] = this.copy(method = method).execute()
+
+  override def execute(): Future[Response] = this.test(this)
+
+  override def withRequestTimeout(timeout: Duration): Self = this.copy(requestTimeout = Some(timeout.toSeconds.toInt))
+
+  override def withProxyServer(proxyServer: WSProxyServer): Self = this
+
+  override def withMethod(method: String): Self = this.copy(method = method)
+
+  override def delete(): Future[Response] = this.execute("DELETE")
+
+  override def head(): Future[Response] = this.execute("HEAD")
+
+  override def stream(): Future[Response] = this.execute()
+
+  override def get(): Future[Response] = this.execute("GET")
+
+  override def withVirtualHost(vh: String): Self = this.copy(virtualHost = Some(vh))
+
+  override def withQueryStringParameters(parameters: (String, String)*): Self = {
+    val additional: Iterable[(String, Seq[String])] = parameters.groupBy(_._1).map {
+      case (key, group) => (key, group.map(_._2))
+    }
+    this.copy(queryString = this.queryString ++ additional)
+  }
+
+  override def withAuth(username: String, password: String, scheme: WSAuthScheme): Self =
+    this.copy(auth = Some((username, password, scheme)))
+
+  override def withBody[T](body: T)(implicit writes: BodyWritable[T]): Self =
+    this.copy(body = writes.transform(body))
+
+  override type Response = StandaloneWSResponse
+
+}
+
+case object MockWSRequest {
+  def MockWS(test: (StandaloneWSRequest => Future[StandaloneWSResponse])): StandaloneWSClient =
+    new StandaloneWSClient {
+      override def underlying[T]: T = ???
+
+      override def url(url: String): StandaloneWSRequest = MockWSRequest(
+        test = test,
+        body = EmptyBody,
+        auth = None,
+        followRedirects = None,
+        headers = Map(),
+        contentType = None,
+        cookies = Seq(),
+        virtualHost = None,
+        method = "GET",
+        queryString = Map(),
+        proxyServer = None,
+        calc = None,
+        url = url,
+        uri = URI.create(url),
+        requestTimeout = None
+      )
+
+      override def close(): Unit = {}
+  }
+}

--- a/src/test/scala/io/github/scamandrill/MockWSResponse.scala
+++ b/src/test/scala/io/github/scamandrill/MockWSResponse.scala
@@ -1,0 +1,23 @@
+package io.github.scamandrill
+
+import akka.stream.scaladsl.Source
+import akka.util.ByteString
+import play.api.libs.ws.{StandaloneWSResponse, WSCookie}
+
+case class MockWSResponse(
+  bytes: Option[ByteString],
+  status: Int,
+  headers: Map[String, Seq[String]],
+  statusText: String,
+  cookies: Seq[WSCookie]
+) extends StandaloneWSResponse {
+  override def underlying[T]: T = ???
+
+  override def cookie(name: String): Option[WSCookie] = cookies.find(_.name == name)
+
+  override def body: String = bytes.map(_.utf8String).getOrElse("")
+
+  override def bodyAsBytes: ByteString = bytes.getOrElse(ByteString())
+
+  override def bodyAsSource: Source[ByteString, _] = Source.single(bodyAsBytes)
+}

--- a/src/test/scala/io/github/scamandrill/client/InboundCallsTest.scala
+++ b/src/test/scala/io/github/scamandrill/client/InboundCallsTest.scala
@@ -178,5 +178,24 @@ class InboundCallsTest extends MandrillSpec {
     }
   }
 
+  "InboundSendRaw" should "successfully send a raw message to hook" in {
+    withMockClient("/inbound/send-raw.json"){ wc =>
+      val instance = new MandrillClient(wc)
+      whenReady(instance.inboundSendRaw(MInboundRaw(
+        raw_message = "From: sender@example.com\nTo: mailbox-123@inbound.example.com\nSubject: Some Subject\n\nSome content.",
+        to = List("mailbox-123@inbound.example.com"),
+        mail_from = "sender@example.com",
+        helo = "example.com",
+        client_address = "127.0.0.1"
+      )), defaultTimeout)(_ shouldBe Success(List(
+        MInboundRawResponse(
+          email = "mailbox-123@inbound.example.com",
+          pattern = "mailbox-*",
+          url = "http://example.com/webhook-url"
+        )
+      )))
+    }
+  }
+
 }
 

--- a/src/test/scala/io/github/scamandrill/client/ScamandrillTest.scala
+++ b/src/test/scala/io/github/scamandrill/client/ScamandrillTest.scala
@@ -1,25 +1,8 @@
 package io.github.scamandrill.client
 
 import io.github.scamandrill.MandrillSpec
-import play.api.Configuration
-import play.api.libs.ws.ahc.AhcWSClient
-
 class ScamandrillTest extends MandrillSpec {
-  "Scamandrill" should "create a new WSClient using overridden values from supplied config" in {
-    val instance = Scamandrill(Configuration(
-      "play.ws.ahc.maxConnectionsPerHost" -> 5
-    ))
-    try {
-      instance.ws match {
-        case AhcWSClient(underlying) => underlying.getMaxConnectionsPerHost shouldBe 5
-        case _ => fail("The underlying client should be a AhcWSClient if scamandrill is constructed with no args")
-      }
-    } finally {
-      instance.shutdown()
-    }
-  }
-
-  it should "use the key from application.conf if no config is specified" in {
+  "Scamandrill" should "use the key from application.conf if no config is specified" in {
     val instance = Scamandrill()
     try {
       instance.get().key.key shouldBe "example key"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "2.5.0-SNAPSHOT"
+version in ThisBuild := "2.6.0-SNAPSHOT"


### PR DESCRIPTION
With the update to play 2.6, there is now a standalone library for play-ws. I refactored the application to use the play-ws standalone library per the [upgrade docs](https://www.playframework.com/documentation/2.6.x/WSMigration26) and dropped the mock request library since it doesn't support the play-ws standalone. 